### PR TITLE
Add forwarding of IPv6 bound ports.

### DIFF
--- a/src/wsl_port_forwarding/port_forwarding.py
+++ b/src/wsl_port_forwarding/port_forwarding.py
@@ -62,10 +62,13 @@ class ForwardingManager(object):
         for line in query_out:
             try:
                 items = line.split()
-                if len(items) != ITEM_LENGTH or items[PROTOCOL] != "tcp":
+                if len(items) != ITEM_LENGTH or items[PROTOCOL] not in ["tcp", "tcp6"]:
                     continue
-                local_address, local_port = items[LOCAL_ADDRESS].split(":")
-                foreign_address, _ = items[FOREIGN_ADDRESS].split(":")
+                if items[PROTOCOL] == "tcp":
+                    local_address, local_port = items[LOCAL_ADDRESS].split(":")
+                    foreign_address, _ = items[FOREIGN_ADDRESS].split(":")
+                else:
+                    local_port = items[LOCAL_ADDRESS].split(":")[-1]
                 if items[PID_PROGRAM] == "-":
                     continue
                 # allow program has a slash in the name (i.e. /venv/bin/python3 blah.py)


### PR DESCRIPTION
Ports found to IPv6 addresses (e.g.: `:::1234`) are not exposed. This PR fixes that.